### PR TITLE
[feat] Dev Container設定を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  // Sui dev container leveraging the official Mysten Labs image.
+  "name": "sui_dev",
+  "image": "mysten/sui-tools:devnet",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Mysten.move"
+      ]
+    }
+  },
+  // 起動毎に最新の Sui CLI へ更新
+  "postStartCommand": "bash .devcontainer/update-on-start.sh",
+  // コンテナ作成時に corepack で pnpm を有効化し、app 配下で初回依存関係をインストール
+  "postCreateCommand": "corepack enable && corepack prepare pnpm@latest --activate && cd app && (pnpm install --frozen-lockfile || pnpm install)",
+  // ~/.local/bin を先頭に追加して優先解決
+  "remoteEnv": {
+    "PATH": "${containerEnv:HOME}/.local/bin:${containerEnv:PATH}"
+  },
+  // フロントエンド開発のポート
+  "forwardPorts": [3000, 5173],
+  "portsAttributes": {
+    "3000": { "label": "Web (Next.js)" },
+    "5173": { "label": "Web (Vite)" }
+  }
+}

--- a/.devcontainer/update-on-start.sh
+++ b/.devcontainer/update-on-start.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ユーザー領域（~/.local/bin）の sui / suiup を優先解決できるよう PATH を設定
+export PATH="${HOME}/.local/bin:${PATH}"
+
+# 対象プロファイルを選択（既定: devnet）。必要に応じて環境変数 SUIUP_PROFILE で変更可能
+PROFILE="${SUIUP_PROFILE:-sui@devnet}"
+
+# suiup が未導入ならインストール（冪等）
+if ! command -v suiup >/dev/null 2>&1; then
+  curl -sSfL https://raw.githubusercontent.com/Mystenlabs/suiup/main/install.sh | sh || true
+fi
+
+# 選択したプロファイルの最新化を試行（存在しなければインストール）
+if command -v sui >/dev/null 2>&1; then
+  suiup update "${PROFILE}" -y || true
+else
+  suiup install "${PROFILE}" -y || true
+fi
+
+# 反映されたバージョンを表示（失敗しても起動は継続）
+sui --version || true


### PR DESCRIPTION
## 概要
Sui開発環境のセットアップを効率化するため、VS Code Dev Container設定を追加しました。Mysten Labs公式のsuiツールイメージをベースに、Node.js環境とフロントエンド開発に必要なポート転送設定を含めています。

## 変更内容
- `.devcontainer/devcontainer.json`
    - Sui開発用のDev Container設定を新規追加
    - ベースイメージとして `mysten/sui-tools:devnet` を使用
    - Node.js 22、Git、GitHub CLIの各機能を追加
    - VS Code拡張機能 `Mysten.move` を自動インストール
    - コンテナ作成時にpnpmを有効化し、app配下の依存関係を自動インストール
    - フロントエンド開発用ポート(3000: Next.js, 5173: Vite)を転送設定
- `.devcontainer/update-on-start.sh`
    - コンテナ起動時にSui CLIを最新版に更新するスクリプトを新規追加
    - suiupを利用したdevnetプロファイルの自動更新機能を実装
    - インストール状態に応じてupdate/installを切り替え